### PR TITLE
Minor tweaks and improvements.

### DIFF
--- a/markdownify.js
+++ b/markdownify.js
@@ -1,12 +1,14 @@
-// Onload, take the DOM of the page, get the markdown formatted text out and
-// apply the converter.
-var converter = new Showdown.converter();
-var html = converter.makeHtml(document.body.innerText);
-document.body.innerHTML = html;
+(function(document) {
 
-// Also inject a reference to the default stylesheet to make things look nicer.
-var ss = document.createElement('link');
-ss.type = 'text/css';
-ss.rel = 'stylesheet';
-ss.href = chrome.extension.getURL('markdown.css');
-document.getElementsByTagName('head')[0].appendChild(ss);
+  // Onload, take the DOM of the page, get the markdown formatted text out and
+	// apply the converter.
+	var html = (new Showdown.converter()).makeHtml(document.body.innerText);
+	document.body.innerHTML = html;
+
+	// Also inject a reference to the default stylesheet to make things look nicer.
+	var ss = document.createElement('link');
+	ss.rel = 'stylesheet';
+	ss.href = chrome.extension.getURL('markdown.css');
+	document.head.appendChild(ss);
+
+}(document));


### PR DESCRIPTION
- Wrap everything in an IIFE to avoid polluting the global scope.
- Since we only need to support Chrome, we can safely use `document.head` instead of `document.getElementsByTagName('head')[0]` – we don’t even need it as a fallback!
- Don’t set `ss.type` as it’s not necessary.
