### PR TITLE
Replace `--` with `&mdash;`

### DIFF
--- a/markdownify.js
+++ b/markdownify.js
@@ -3,7 +3,7 @@
   // Onload, take the DOM of the page, get the markdown formatted text out and
 	// apply the converter.
 	var html = (new Showdown.converter()).makeHtml(document.body.innerText);
-  html = html.replace(/--/g, '&mdash;');
+	html = html.replace(/--/g, '&mdash;');
 	document.body.innerHTML = html;
 
 	// Also inject a reference to the default stylesheet to make things look nicer.


### PR DESCRIPTION
Not sure if my code snippet belongs in the `markdownify.js` file — I could always move it to `showdown.js`.

But, with Posterous' markdown converter, I know double dashes are replaced with `&mdash;` HTML entities, so I added a line to do the same.
