### PR TITLE
Prevent matching "*.md.html" in URLs.

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -10,8 +10,9 @@
   "content_scripts": [
     {
       "matches": [
-        "http://*/*.md*"      , "file://*/*.md", 
-        "http://*/*.markdown*", "file://*/*.markdown",
+        "http://*/*.md?*"     , "http://*/*.markdown?*",
+        "http://*/*.md"       , "file://*/*.md",
+        "http://*/*.markdown" , "file://*/*.markdown",
         "http://*/*.text"     , "file://*/*.text"
       ],
       "js": ["showdown.js", "markdownify.js"]


### PR DESCRIPTION
For example the PhoneGap documentation:

http://docs.phonegap.com/en/2.0.0/guide_getting-started_index.md.html

Is detected (incorrectly) as Markdown, making it extremely hard to read.
