### PR TITLE
Support literate coffeescript

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -7,6 +7,9 @@
     "48": "images/icon.png",
     "16": "images/icon.png"
   },
+  "web_accessible_resources": [
+    "markdown.css"
+  ],
   "content_scripts": [
     {
       "matches": [
@@ -18,5 +21,6 @@
       "js": ["showdown.js", "markdownify.js"]
     }
   ],
-  "permissions": ["tabs", "<all_urls>"]
+  "permissions": ["tabs", "<all_urls>"],
+  "manifest_version": 2
 }


### PR DESCRIPTION
Stopgap for issue #28
- Supports literate coffeescript extensions (.litcoffee)
- Added manifest version and added css to web accessible resources.
