### PR TITLE
Fix file:// URLs not matching tail wildcard

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -10,8 +10,8 @@
   "content_scripts": [
     {
       "matches": [
-        "http://*/*.md*"      , "file://*/*.md", 
-        "http://*/*.markdown*", "file://*/*.markdown",
+        "http://*/*.md*"      , "file://*/*.md*",
+        "http://*/*.markdown*", "file://*/*.markdown*",
         "http://*/*.text"     , "file://*/*.text"
       ],
       "js": ["showdown.js", "markdownify.js"]


### PR DESCRIPTION
Ensure that URLs such as `file://foo/bar/baz.md?busted` are matched.
