### PR TITLE
Added Theme support.

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -7,6 +7,10 @@
     "48": "images/icon.png",
     "16": "images/icon.png"
   },
+    "options_ui": {
+    "page": "options.html",
+    "chrome_style": true
+  },
   "content_scripts": [
     {
       "matches": [
@@ -18,9 +22,10 @@
       "js": ["showdown.js", "markdownify.js"]
     }
   ],
-  "permissions": ["tabs", "<all_urls>"],
+  "permissions": ["tabs", "<all_urls>", "storage"],
   "manifest_version": 2,
   "web_accessible_resources": [
-    "markdown.css"
+    "themes/originalTheme.css",
+    "themes/cleanTheme.css"
   ]
 }

--- a/markdown.css
+++ b/markdown.css
@@ -1,74 +1,177 @@
-*{margin:0;padding:0;}
+/* This is an alternative theme for Google Markdown Preview created by borismus [https://github.com/borismus/markdown-preview]
+*
+*  Theme created by c_nak[https://github.com/cnak]
+*
+* */
+
+* {
+    margin: 10px;
+    padding: 0 10px;
+}
 body {
-    font:13.34px helvetica,arial,freesans,clean,sans-serif;
-    color:black;
-    line-height:1.4em;
-    background-color: #F8F8F8;
-    padding: 0.7em;
+    color: rgb(100, 100, 100);
+    line-height: 1.7em;
+    background-color: white;
+    padding: 0 1.9em;
 }
 p {
-    margin:1em 0;
-    line-height:1.5em;
+    margin: 1em 0;
+    line-height: 1.7em;
 }
 table {
-    font-size:inherit;
-    font:100%;
-    margin:1em;
+    font-size: inherit;
+    font: 100%;
+    margin: 1em;
 }
-table th{border-bottom:1px solid #bbb;padding:.2em 1em;}
-table td{border-bottom:1px solid #ddd;padding:.2em 1em;}
-input[type=text],input[type=password],input[type=image],textarea{font:99% helvetica,arial,freesans,sans-serif;}
-select,option{padding:0 .25em;}
-optgroup{margin-top:.5em;}
-pre,code{font:12px Monaco,"Courier New","DejaVu Sans Mono","Bitstream Vera Sans Mono",monospace;}
+table th {
+    border-bottom: 1px solid #bbb;
+    padding: .2em 1em;
+}
+table td {
+    border-bottom: 1px solid #ddd;
+    padding: .2em 1em;
+}
+input[type=text],
+input[type=password],
+input[type=image],
+textarea {
+    font: 99% helvetica, arial, freesans, sans-serif;
+}
+select,
+option {
+    padding: 0 .25em;
+}
+optgroup {
+    margin-top: .5em;
+}
+pre,
+code {
+    font: 12px Monaco, "Courier New", "DejaVu Sans Mono", "Bitstream Vera Sans Mono", monospace;
+}
 pre {
-    margin:1em 0;
-    font-size:12px;
-    background-color:#eee;
-    border:1px solid #ddd;
-    padding:5px;
-    line-height:1.5em;
-    color:#444;
-    overflow:auto;
-    -webkit-box-shadow:rgba(0,0,0,0.07) 0 1px 2px inset;
-    -webkit-border-radius:3px;
-    -moz-border-radius:3px;border-radius:3px;
+    margin: 1em 0;
+    font-size: 12px;
+    background-color: #eee;
+    border: 1px solid #ddd;
+    padding: 5px;
+    line-height: 1.5em;
+    color: #444;
+    overflow: auto;
+    -webkit-box-shadow: rgba(0, 0, 0, 0.07) 0 1px 2px inset;
+    -webkit-border-radius: 3px;
+    -moz-border-radius: 3px;
+    border-radius: 3px;
 }
 pre code {
-    padding:0;
-    font-size:12px;
-    background-color:#eee;
-    border:none;
+    padding: 0;
+    font-size: 12px;
+    background-color: #eee;
+    border: none;
 }
 code {
-    font-size:12px;
-    background-color:#f8f8ff;
-    color:#444;
-    padding:0 .2em;
-    border:1px solid #dedede;
+    font-size: 12px;
+    background-color: #f8f8ff;
+    color: #444;
+    padding: 0 .2em;
+    border: 1px solid #dedede;
 }
-img{border:0;max-width:100%;}
-abbr{border-bottom:none;}
-a{color:#4183c4;text-decoration:none;}
-a:hover{text-decoration:underline;}
-a code,a:link code,a:visited code{color:#4183c4;}
-h2,h3{margin:1em 0;}
-h1,h2,h3,h4,h5,h6{border:0;}
-h1{font-size:170%;border-top:4px solid #aaa;padding-top:.5em;margin-top:1.5em;}
-h1:first-child{margin-top:0;padding-top:.25em;border-top:none;}
-h2{font-size:150%;margin-top:1.5em;border-top:4px solid #e0e0e0;padding-top:.5em;}
-h3{margin-top:1em;}
-hr{border:1px solid #ddd;}
-ul{margin:1em 0 1em 2em;}
-ol{margin:1em 0 1em 2em;}
-ul li,ol li{margin-top:.5em;margin-bottom:.5em;}
-ul ul,ul ol,ol ol,ol ul{margin-top:0;margin-bottom:0;}
-blockquote{margin:1em 0;border-left:5px solid #ddd;padding-left:.6em;color:#555;}
-dt{font-weight:bold;margin-left:1em;}
-dd{margin-left:2em;margin-bottom:1em;}
+img {
+    border: 0;
+    max-width: 100%;
+}
+abbr {
+    border-bottom: none;
+}
+a {
+    color: #4183c4;
+    text-decoration: none;
+}
+a:hover {
+    text-decoration: underline;
+}
+a code,
+a:link code,
+a:visited code {
+    color: #4183c4;
+}
+h2,
+h3 {
+    margin: 1em 0;
+}
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+    border: 0;
+    color: black;
+}
+h1 {
+    border-top: 1px solid #aaa;
+    padding-top: .9em;
+    margin-top: 1.5em;
+    font: 4.0em "Helvetica Neue", "Open Sans", sans-serif;
+    color: #353535;
+    font-weight: 100;
+}
+h1:first-child {
+    margin-top: 0;
+    padding-top: .25em;
+    border-top: none;
+}
+h1:first-letter {
+    color: red;
+}
+h2 {
+    font-size: 150%;
+    margin-top: 1.5em;
+    padding-top: .5em;
+    font: 200 2.0em "Helvetica Neue", "Open Sans", sans-serif;
+}
+h3 {
+    margin-top: 1em;
+    color: #AAAAAA;
+    font: 200 1.2em "Helvetica Neue", "Open Sans", sans-serif;
+}
+hr {
+    border: 1px solid #ddd;
+}
+ul {
+    margin: 1em 0 1em 2em;
+}
+ol {
+    margin: 1em 0 1em 2em;
+}
+ul li,
+ol li {
+    margin-top: .7em;
+    margin-bottom: .7em;
+}
+ul ul,
+ul ol,
+ol ol,
+ol ul {
+    margin-top: 0;
+    margin-bottom: 0;
+}
+blockquote {
+    margin: 1em 0;
+    border-left: 5px solid #ddd;
+    padding-left: .6em;
+    color: #555;
+}
+dt {
+    font-weight: bold;
+    margin-left: 1em;
+}
+dd {
+    margin-left: 2em;
+    margin-bottom: 1em;
+}
 @media screen and (min-width: 768px) {
     body {
-        width: 748px;
-        margin:10px auto;
+        width: 650px;
+        margin: 10px auto;
     }
 }

--- a/markdownify.js
+++ b/markdownify.js
@@ -8,7 +8,14 @@
 	// Also inject a reference to the default stylesheet to make things look nicer.
 	var ss = document.createElement('link');
 	ss.rel = 'stylesheet';
-	ss.href = chrome.extension.getURL('markdown.css');
+
+ chrome.storage.sync.get({
+    currentTheme: 'originalTheme',
+  }, function(items) {
+    var themeName = "themes/" + items.currentTheme + ".css";
+     ss.href = chrome.extension.getURL(themeName);
+  });
+
 	document.head.appendChild(ss);
 
 }(document));

--- a/options.html
+++ b/options.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Markdown Preview Options</title>
+  <style>
+    body: { padding: 100px; }
+  </style>
+</head>
+
+<body>
+  Select theme:
+  <select id="theme">
+   <option value="originalTheme">Original</option>
+   <option value="cleanTheme">Clean</option>
+  </select>
+
+  <div id="status"></div>
+  <button id="save">Save</button>
+
+  <script src="options.js"></script>
+</body>
+</html>

--- a/options.js
+++ b/options.js
@@ -1,0 +1,27 @@
+// Saves options to chrome.storage.sync.
+function save_options() {
+  var theme = document.getElementById('theme').value;
+  chrome.storage.sync.set({
+    currentTheme: theme,
+  }, function() {
+    // Update status to let user know options were saved.
+    var status = document.getElementById('status');
+    status.textContent = 'Options saved.';
+    setTimeout(function() {
+      status.textContent = '';
+    }, 750);
+  });
+}
+
+function restore_options() {
+  // Use default value theme = 'original'
+  chrome.storage.sync.get({
+    currentTheme: 'originalTheme',
+  }, function(items) {
+    document.getElementById('theme').value = items.currentTheme;
+  });
+}
+
+document.addEventListener('DOMContentLoaded', restore_options);
+document.getElementById('save').addEventListener('click',
+    save_options);

--- a/themes/cleanTheme.css
+++ b/themes/cleanTheme.css
@@ -1,9 +1,3 @@
-/* This is an alternative theme for Google Markdown Preview created by borismus [https://github.com/borismus/markdown-preview]
-*
-*  Theme created by c_nak[https://github.com/cnak]
-*
-* */
-
 * {
     margin: 10px;
     padding: 0 10px;

--- a/themes/cleanTheme.css
+++ b/themes/cleanTheme.css
@@ -1,3 +1,7 @@
+/*
+ * Clean theme for Markdown Preview by c_nak [https://github.com/cnak]
+ * for Markdown Preview borismus
+ */
 * {
     margin: 10px;
     padding: 0 10px;

--- a/themes/originalTheme.css
+++ b/themes/originalTheme.css
@@ -1,0 +1,74 @@
+*{margin:0;padding:0;}
+body {
+    font:13.34px helvetica,arial,freesans,clean,sans-serif;
+    color:black;
+    line-height:1.4em;
+    background-color: #F8F8F8;
+    padding: 0.7em;
+}
+p {
+    margin:1em 0;
+    line-height:1.5em;
+}
+table {
+    font-size:inherit;
+    font:100%;
+    margin:1em;
+}
+table th{border-bottom:1px solid #bbb;padding:.2em 1em;}
+table td{border-bottom:1px solid #ddd;padding:.2em 1em;}
+input[type=text],input[type=password],input[type=image],textarea{font:99% helvetica,arial,freesans,sans-serif;}
+select,option{padding:0 .25em;}
+optgroup{margin-top:.5em;}
+pre,code{font:12px Monaco,"Courier New","DejaVu Sans Mono","Bitstream Vera Sans Mono",monospace;}
+pre {
+    margin:1em 0;
+    font-size:12px;
+    background-color:#eee;
+    border:1px solid #ddd;
+    padding:5px;
+    line-height:1.5em;
+    color:#444;
+    overflow:auto;
+    -webkit-box-shadow:rgba(0,0,0,0.07) 0 1px 2px inset;
+    -webkit-border-radius:3px;
+    -moz-border-radius:3px;border-radius:3px;
+}
+pre code {
+    padding:0;
+    font-size:12px;
+    background-color:#eee;
+    border:none;
+}
+code {
+    font-size:12px;
+    background-color:#f8f8ff;
+    color:#444;
+    padding:0 .2em;
+    border:1px solid #dedede;
+}
+img{border:0;max-width:100%;}
+abbr{border-bottom:none;}
+a{color:#4183c4;text-decoration:none;}
+a:hover{text-decoration:underline;}
+a code,a:link code,a:visited code{color:#4183c4;}
+h2,h3{margin:1em 0;}
+h1,h2,h3,h4,h5,h6{border:0;}
+h1{font-size:170%;border-top:4px solid #aaa;padding-top:.5em;margin-top:1.5em;}
+h1:first-child{margin-top:0;padding-top:.25em;border-top:none;}
+h2{font-size:150%;margin-top:1.5em;border-top:4px solid #e0e0e0;padding-top:.5em;}
+h3{margin-top:1em;}
+hr{border:1px solid #ddd;}
+ul{margin:1em 0 1em 2em;}
+ol{margin:1em 0 1em 2em;}
+ul li,ol li{margin-top:.5em;margin-bottom:.5em;}
+ul ul,ul ol,ol ol,ol ul{margin-top:0;margin-bottom:0;}
+blockquote{margin:1em 0;border-left:5px solid #ddd;padding-left:.6em;color:#555;}
+dt{font-weight:bold;margin-left:1em;}
+dd{margin-left:2em;margin-bottom:1em;}
+@media screen and (min-width: 768px) {
+    body {
+        width: 748px;
+        margin:10px auto;
+    }
+}


### PR DESCRIPTION
Added options to select different themes.

- Themes are now in located under /themes directory
- Added an options panel to select different themes
- Renamed the default theme "markdown.css" to "originalTheme.css"
- Added an additional theme called "cleanTheme.css" as an alternative theme to the original theme

Pictures attached

Thank you

Ced

Options panel 
![2015-05-31 17 58 10](https://cloud.githubusercontent.com/assets/218601/7902823/c9a73ab6-07be-11e5-9925-b52ccff1b482.png)

Original Theme alongside the new "Clean" theme
![comparethemes](https://cloud.githubusercontent.com/assets/218601/7902824/cd94d0de-07be-11e5-8075-7b3de6582080.jpg)

